### PR TITLE
fixed typo for zend-loader

### DIFF
--- a/module/MyCompany/tests/bootstrap.php
+++ b/module/MyCompany/tests/bootstrap.php
@@ -98,7 +98,7 @@ class Bootstrap
             include $vendorPath . '/autoload.php';
         }
         
-        include $zf2Path . '/zend-Loader/src/AutoloaderFactory.php';
+        include $zf2Path . '/zend-loader/src/AutoloaderFactory.php';
         AutoloaderFactory::factory(array(
             'Zend\Loader\StandardAutoloader' => array(
                 'autoregister_zf' => true,


### PR DESCRIPTION
fix for error below:

PHP Warning:  include(/var/www/vendor/zendframework/zend-Loader/src/AutoloaderFactory.php): failed to open stream: No such file or directory in /var/www/module/MyCompany/tests/bootstrap.php on line 101
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/local/bin/phpunit:569
PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:113
PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:124
PHP   5. PHPUnit_TextUI_Command->handleBootstrap() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:704
PHP   6. PHPUnit_Util_Fileloader::checkAndLoad() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:875
PHP   7. PHPUnit_Util_Fileloader::load() phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php:38
PHP   8. include_once() phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php:56
PHP   9. MyCompany\Bootstrap::init() /var/www/module/MyCompany/tests/bootstrap.php:127
PHP  10. MyCompany\Bootstrap::initAutoloader() /var/www/module/MyCompany/tests/bootstrap.php:39
PHP Warning:  include(): Failed opening '/var/www/vendor/zendframework/zend-Loader/src/AutoloaderFactory.php' for inclusion (include_path='.:/usr/share/php:/usr/share/pear') in /var/www/module/MyCompany/tests/bootstrap.php on line 101
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/local/bin/phpunit:569
PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:113
PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:124
PHP   5. PHPUnit_TextUI_Command->handleBootstrap() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:704
PHP   6. PHPUnit_Util_Fileloader::checkAndLoad() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:875
PHP   7. PHPUnit_Util_Fileloader::load() phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php:38
PHP   8. include_once() phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php:56
PHP   9. MyCompany\Bootstrap::init() /var/www/module/MyCompany/tests/bootstrap.php:127
PHP  10. MyCompany\Bootstrap::initAutoloader() /var/www/module/MyCompany/tests/bootstrap.php:39
PHPUnit 5.4.7 by Sebastian Bergmann and contributors.
