### PR TITLE
added scheme for chrome

### DIFF
--- a/module/MyCompany/Module.php
+++ b/module/MyCompany/Module.php
@@ -6,6 +6,9 @@ use Zend\Mvc\MvcEvent;
 
 class Module
 {
+    public function __construct() {
+        UriFactory::registerScheme('chrome-extension', 'Zend\Uri\Uri');
+    }
 
     public function getConfig()
     {


### PR DESCRIPTION
Not sure if this is the best way to do this, but it was added to fix the error below when trying to post using postman on chrome.

Fatal error: Uncaught exception 'Zend\Uri\Exception\InvalidArgumentException' with message 'no class registered for scheme "chrome-extension"'